### PR TITLE
Use cucumber-jvm 1.1.6-SNAPSHOT, which fixes a bug with stepdefs.json

### DIFF
--- a/.cucumber/stepdefs.json
+++ b/.cucumber/stepdefs.json
@@ -1,0 +1,106 @@
+[
+  {
+    "steps": [
+      {
+        "name": "I am on Google home page",
+        "args": []
+      }
+    ],
+    "source": "^I am on Google home page$",
+    "flags": ""
+  },
+  {
+    "steps": [
+      {
+        "name": "I enter the keyword of \"Cheese\"",
+        "args": [
+          {
+            "offset": 24,
+            "val": "Cheese"
+          }
+        ]
+      },
+      {
+        "name": "I enter the keyword of \"Mickey Mouse\"",
+        "args": [
+          {
+            "offset": 24,
+            "val": "Mickey Mouse"
+          }
+        ]
+      },
+      {
+        "name": "I enter the keyword of \"Star Wars\"",
+        "args": [
+          {
+            "offset": 24,
+            "val": "Star Wars"
+          }
+        ]
+      },
+      {
+        "name": "I enter the keyword of \"Tinker Bell\"",
+        "args": [
+          {
+            "offset": 24,
+            "val": "Tinker Bell"
+          }
+        ]
+      }
+    ],
+    "source": "^I enter the keyword of \"([^\"]*)\"$",
+    "flags": ""
+  },
+  {
+    "steps": [
+      {
+        "name": "click the Submit button",
+        "args": []
+      }
+    ],
+    "source": "^click the Submit button$",
+    "flags": ""
+  },
+  {
+    "steps": [
+      {
+        "name": "the page title returned is \"Cheese - Google Search\"",
+        "args": [
+          {
+            "offset": 28,
+            "val": "Cheese - Google Search"
+          }
+        ]
+      },
+      {
+        "name": "the page title returned is \"Mickey Mouse - Google Search\"",
+        "args": [
+          {
+            "offset": 28,
+            "val": "Mickey Mouse - Google Search"
+          }
+        ]
+      },
+      {
+        "name": "the page title returned is \"Star Wars - Google Search\"",
+        "args": [
+          {
+            "offset": 28,
+            "val": "Star Wars - Google Search"
+          }
+        ]
+      },
+      {
+        "name": "the page title returned is \"Tinker Bell - Google Search\"",
+        "args": [
+          {
+            "offset": 28,
+            "val": "Tinker Bell - Google Search"
+          }
+        ]
+      }
+    ],
+    "source": "^the page title returned is \"([^\"]*)\"$",
+    "flags": ""
+  }
+]

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <gmavenplus.version>1.0</gmavenplus.version>
         <groovy.version>2.2.1</groovy.version>
         <selenium.version>2.40.0</selenium.version>
-        <cucumber.version>1.1.5</cucumber.version>
+        <cucumber.version>1.1.6-SNAPSHOT</cucumber.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!--
             Setting the output encoding property to UTF-8 avoids those pesky


### PR DESCRIPTION
Cucumber-JVM 1.1.5 would only write out `stepdefs.json` if you were using the command-line runner (`cucumber.api.cli.Main`), but not if you were using the JUnit runner (which you're using).

This bug was fixed in cucumber/cucumber-jvm#3e4dae2c35f99d424f7a1a5f447ba36aced51aa1, which is currently in cucumber-jvm 1.1.6-SNAPSHOT.

We plan on releasing 1.1.6 in a week or two, but it should be ok to use the snapshot in the interim.
